### PR TITLE
Fix e2e workflow container

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,6 +13,8 @@ jobs:
         image: vaultwarden/server:latest
         ports:
           - 8081:80
+        env:
+          I_REALLY_WANT_VOLATILE_STORAGE: 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- set `I_REALLY_WANT_VOLATILE_STORAGE` for the Vaultwarden service so e2e tests can run

## Testing
- `npm ci` *(fails: 404 Not Found for `@wdio/chromedriver-service`)*

------
https://chatgpt.com/codex/tasks/task_e_688c2d1feb4c832b9e3807a68a1e082d