### PR TITLE
Prevent workflows from coming back when syncing upstream

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto eol=lf
+.github/workflows/* merge=ours

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,7 @@ apps/**/config/local.json
 # Nx
 .nx
 .env
+
+# Ignore upstream workflows but keep our own
+.github/workflows/*
+!.github/workflows/e2e.yml

--- a/README.md
+++ b/README.md
@@ -33,3 +33,7 @@ Interested in contributing in a big way? Consider joining our team! We're hiring
 Code contributions are welcome! Please commit any pull requests against the `main` branch. Learn more about how to contribute by reading the [Contributing Guidelines](https://contributing.bitwarden.com/contributing/). Check out the [Contributing Documentation](https://contributing.bitwarden.com/) for how to get started with your first contribution.
 
 Security audits and feedback are welcome. Please open an issue or email us privately if the report is sensitive in nature. You can read our security policy in the [`SECURITY.md`](SECURITY.md) file.
+
+## Syncing with the parent repository
+
+To update this fork with the latest code from the upstream repository while keeping the removed GitHub Actions workflows absent, run `./scripts/sync-upstream.sh`. The script fetches the upstream `main` branch and deletes any workflow files other than `e2e.yml` before committing, ensuring that only application code is pulled in.

--- a/scripts/sync-upstream.sh
+++ b/scripts/sync-upstream.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Sync changes from the upstream repository while preserving local workflow removals.
+set -euo pipefail
+
+REMOTE="${1:-upstream}"
+BRANCH="${2:-main}"
+
+# Fetch and merge the upstream branch
+git fetch "$REMOTE"
+git merge "${REMOTE}/${BRANCH}" --no-edit
+
+# Remove any workflow files added from upstream except those we track
+if [ -d ".github/workflows" ]; then
+  find .github/workflows -type f ! -name 'e2e.yml' -exec git rm -f {} + 2>/dev/null || true
+fi
+
+# Only create a commit if there are staged changes
+if ! git diff --cached --quiet; then
+  git commit -m "Remove upstream workflows"
+fi


### PR DESCRIPTION
## Summary
- configure git to keep local workflow removals
- ignore any upstream workflow files
- add helper script `scripts/sync-upstream.sh`
- document how to sync with upstream safely

## Testing
- `npm install` *(fails: package @wdio/chromedriver-service not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c2c89641c832bb145c1c1bb77c2b6