### PR TITLE
Add e2e workflows for each client

### DIFF
--- a/.github/workflows/e2e-browser.yml
+++ b/.github/workflows/e2e-browser.yml
@@ -1,0 +1,33 @@
+name: E2E Tests (Browser)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  e2e-browser:
+    runs-on: ubuntu-latest
+    services:
+      vaultwarden:
+        image: vaultwarden/server:latest
+        env:
+          I_REALLY_WANT_VOLATILE_STORAGE: 'true'
+        ports:
+          - 8081:80
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Build browser extension
+        run: |
+          cd apps/browser
+          npm run build:prod:chrome
+          cd ../..
+      - name: Run E2E tests
+        run: |
+          APP=browser EXTENSION_PATH=$(pwd)/apps/browser/build npm run test:e2e

--- a/.github/workflows/e2e-cli.yml
+++ b/.github/workflows/e2e-cli.yml
@@ -1,0 +1,33 @@
+name: E2E Tests (CLI)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  e2e-cli:
+    runs-on: ubuntu-latest
+    services:
+      vaultwarden:
+        image: vaultwarden/server:latest
+        env:
+          I_REALLY_WANT_VOLATILE_STORAGE: 'true'
+        ports:
+          - 8081:80
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Build CLI app
+        run: |
+          cd apps/cli
+          npm run build:oss:prod
+          cd ../..
+      - name: Run E2E tests
+        run: |
+          APP=cli CLI_COMMAND="node $(pwd)/apps/cli/build/bw.js" npm run test:e2e

--- a/.github/workflows/e2e-desktop.yml
+++ b/.github/workflows/e2e-desktop.yml
@@ -1,0 +1,33 @@
+name: E2E Tests (Desktop)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  e2e-desktop:
+    runs-on: ubuntu-latest
+    services:
+      vaultwarden:
+        image: vaultwarden/server:latest
+        env:
+          I_REALLY_WANT_VOLATILE_STORAGE: 'true'
+        ports:
+          - 8081:80
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Build desktop app
+        run: |
+          cd apps/desktop
+          npm run build
+          cd ../..
+      - name: Run E2E tests
+        run: |
+          APP=desktop DESKTOP_PATH=$(pwd)/apps/desktop/build npm run test:e2e


### PR DESCRIPTION
## Summary
- add browser E2E workflow
- add CLI E2E workflow
- add desktop E2E workflow
- enable volatile storage for Vaultwarden services

## Testing
- `npm ci` *(fails: Not Found - GET https://registry.npmjs.org/@wdio%2fchromedriver-service)*

------
https://chatgpt.com/codex/tasks/task_e_688c2c1bec00832baaf4fe75c10cf574